### PR TITLE
Line 598 wimplicit-function-declaration warning resolved

### DIFF
--- a/libcob/call.c
+++ b/libcob/call.c
@@ -28,6 +28,7 @@
 #include <ctype.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <strings.h>
 #ifdef	HAVE_UNISTD_H
 #include <unistd.h>
 #endif
@@ -586,7 +587,7 @@ cob_init_call (void)
 #ifndef	COB_ALT_HASH
 	call_table = cob_malloc (sizeof (struct call_hash *) * HASH_SIZE);
 #endif
-
+        int strcasecmp (const char *, const char *);
 	call_filename_buff = cob_malloc (CALL_FILEBUFF_SIZE);
 	call_entry_buff = cob_malloc (COB_SMALL_BUFF);
 	call_entry2_buff = cob_malloc (COB_SMALL_BUFF);

--- a/vbisam/libvbisam/vblowlevel.c
+++ b/vbisam/libvbisam/vblowlevel.c
@@ -39,7 +39,7 @@ ivbopen (const char *pcfilename, const int iflags, const mode_t tmode)
 		iinitialized = 1;
 	}
 	if (stat (pcfilename, &sstat)) {
-		if (!iflags & O_CREAT) {
+		if (~iflags & O_CREAT) {
 			return -1;
 		}
 	} else {


### PR DESCRIPTION
Solution: Include the header file strings.h
And also declare strcasecmp before with this statement : 
int strcasesmp (const char *, const char *);