### PR TITLE
Line 964 wimplicit declaration warning resolved

### DIFF
--- a/libcob/call.c
+++ b/libcob/call.c
@@ -28,6 +28,7 @@
 #include <ctype.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <strings.h>
 #ifdef	HAVE_UNISTD_H
 #include <unistd.h>
 #endif
@@ -586,7 +587,7 @@ cob_init_call (void)
 #ifndef	COB_ALT_HASH
 	call_table = cob_malloc (sizeof (struct call_hash *) * HASH_SIZE);
 #endif
-
+        int strcasecmp (const char *, const char *);
 	call_filename_buff = cob_malloc (CALL_FILEBUFF_SIZE);
 	call_entry_buff = cob_malloc (COB_SMALL_BUFF);
 	call_entry2_buff = cob_malloc (COB_SMALL_BUFF);

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -1814,7 +1814,7 @@ cob_accept_time (cob_field *f)
 	time_t		t;
 #if defined(HAVE_SYS_TIME_H) && defined(HAVE_GETTIMEOFDAY)
 	struct timeval	tmv;
-	char		buff2[8];
+	char		buff2[18];
 #endif
 #endif
 	char		s[12];

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -27,6 +27,7 @@
 #include <string.h>
 #include <ctype.h>
 #include <time.h>
+#include <strings.h>
 
 #ifdef	HAVE_UNISTD_H
 #include <unistd.h>

--- a/vbisam/libvbisam/vblowlevel.c
+++ b/vbisam/libvbisam/vblowlevel.c
@@ -39,7 +39,7 @@ ivbopen (const char *pcfilename, const int iflags, const mode_t tmode)
 		iinitialized = 1;
 	}
 	if (stat (pcfilename, &sstat)) {
-		if (!iflags & O_CREAT) {
+		if (~iflags & O_CREAT) {
 			return -1;
 		}
 	} else {

--- a/vbisam/libvbisam/vblowlevel.c
+++ b/vbisam/libvbisam/vblowlevel.c
@@ -39,7 +39,7 @@ ivbopen (const char *pcfilename, const int iflags, const mode_t tmode)
 		iinitialized = 1;
 	}
 	if (stat (pcfilename, &sstat)) {
-		if (~iflags & O_CREAT) {
+		if (!iflags & O_CREAT) {
 			return -1;
 		}
 	} else {


### PR DESCRIPTION
Solution - Include the header file strings.h at the start
After executing the make command we will get this following statement :
 gcc -DHAVE_CONFIG_H  -I.. -I.. -I.. -I.. -O2 -finline-functions -fsigned-char -Wall -Wwrite-strings -Wmissing-prototype
s -Wno-format-y2k -MT libcob_la-common.lo -MD -MP -MF .deps/libcob_la-common.Tpo -c common.c  -fPIC -DPIC -o .libs/libcob_la-common.o

Try to remove the first to -I and the statement would be like this:
 gcc -DHAVE_CONFIG_H  -I.. -I.. -O2 -finline-functions -fsigned-char -Wall -Wwrite-strings -Wmissing-prototype
s -Wno-format-y2k -MT libcob_la-common.lo -MD -MP -MF .deps/libcob_la-common.Tpo -c common.c  -fPIC -DPIC -o .libs/libcob_la-common.o
And execute it.