### PR TITLE
Warnings resolved in vbisam file

### DIFF
--- a/vbisam/libvbisam/ischeck.c
+++ b/vbisam/libvbisam/ischeck.c
@@ -145,7 +145,7 @@ ibittestandreset (char *psmap, off_t tbit)
 }
 
 static int
-ipreamble (ihandle)
+ipreamble (int ihandle)
 {
 	struct DICTINFO	*psvbptr;
 	struct stat	sstat;

--- a/vbisam/libvbisam/isdelete.c
+++ b/vbisam/libvbisam/isdelete.c
@@ -28,7 +28,7 @@ irowdelete (const int ihandle, off_t trownumber)
 {
 	struct DICTINFO	*psvbptr;
 	int		ikeynumber, iresult;
-	off_t		tdupnumber[MAXSUBS];
+	off_t		tdupnumber[MAXSUBS] __attribute__((unused));
 
 	psvbptr = psvbfile[ihandle];
 	/*

--- a/vbisam/libvbisam/isdelete.c
+++ b/vbisam/libvbisam/isdelete.c
@@ -28,7 +28,6 @@ irowdelete (const int ihandle, off_t trownumber)
 {
 	struct DICTINFO	*psvbptr;
 	int		ikeynumber, iresult;
-	off_t		tdupnumber[MAXSUBS] __attribute__((unused));
 
 	psvbptr = psvbfile[ihandle];
 	/*
@@ -43,7 +42,6 @@ irowdelete (const int ihandle, off_t trownumber)
 			iserrno = EBADFILE;
 			return -1;
 		}
-		tdupnumber[ikeynumber] = psvbptr->pskeycurr[ikeynumber]->tdupnumber;
 	}
 
 	/*

--- a/vbisam/libvbisam/isrecover.c
+++ b/vbisam/libvbisam/isrecover.c
@@ -319,7 +319,7 @@ ircvcommit (char *pcbuffer)
 static int
 ircvdelete (char *pcbuffer)
 {
-	char	*pcrow;
+	char	*pcrow __attribute__((unused));
 	off_t	trownumber;
 	int	ihandle, ipid;
 
@@ -396,7 +396,8 @@ static int
 ircvfileclose (char *pcbuffer)
 {
 	struct RCV_HDL	*psrcv;
-	int		ihandle, ivarlenflag, ipid;
+	int		ihandle, ipid;
+	int             ivarlenflag __attribute__((unused));
 
 	ihandle = inl_ldint (pcbuffer);
 	ivarlenflag = inl_ldint (pcbuffer + INTSIZE);
@@ -550,7 +551,7 @@ ircvuniqueid (char *pcbuffer)
 	if (tuniqueid != inl_ldquad (psvbfile[ihandle]->sdictnode.cuniqueid)) {
 		return EBADFILE;
 	}
-	isuniqueid (ihandle, &tuniqueid);
+	extern int isuniqueid (const int ihandle, vbisam_off_t *ptuniqueid);
 	return 0;
 }
 

--- a/vbisam/libvbisam/isrecover.c
+++ b/vbisam/libvbisam/isrecover.c
@@ -319,7 +319,6 @@ ircvcommit (char *pcbuffer)
 static int
 ircvdelete (char *pcbuffer)
 {
-	char	*pcrow __attribute__((unused));
 	off_t	trownumber;
 	int	ihandle, ipid;
 
@@ -333,7 +332,6 @@ ircvdelete (char *pcbuffer)
 		return ENOTOPEN;
 	}
 	trownumber = inl_ldquad (pcbuffer + INTSIZE);
-	pcrow = pcbuffer + INTSIZE + QUADSIZE + INTSIZE;
 	isdelrec (ihandle, trownumber);
 	return iserrno;
 }
@@ -397,10 +395,9 @@ ircvfileclose (char *pcbuffer)
 {
 	struct RCV_HDL	*psrcv;
 	int		ihandle, ipid;
-	int             ivarlenflag __attribute__((unused));
 
 	ihandle = inl_ldint (pcbuffer);
-	ivarlenflag = inl_ldint (pcbuffer + INTSIZE);
+	inl_ldint (pcbuffer + INTSIZE);
 	ipid = inl_ldint (psvblogheader->cpid);
 	if (iignore (ipid)) {
 		return 0;

--- a/vbisam/libvbisam/isrecover.c
+++ b/vbisam/libvbisam/isrecover.c
@@ -551,7 +551,7 @@ ircvuniqueid (char *pcbuffer)
 	if (tuniqueid != inl_ldquad (psvbfile[ihandle]->sdictnode.cuniqueid)) {
 		return EBADFILE;
 	}
-	extern int isuniqueid (const int ihandle, vbisam_off_t *ptuniqueid);
+        issetunique (ihandle, tuniqueid);
 	return 0;
 }
 

--- a/vbisam/libvbisam/vbmemio.c
+++ b/vbisam/libvbisam/vbmemio.c
@@ -48,7 +48,7 @@ pvvbmalloc (const size_t size)
 
 	mptr = calloc (1, size);
 	if (unlikely(!mptr)) {
-		fprintf (stderr, "Cannot allocate %d bytes of memory - Aborting\n", size);
+		fprintf (stderr, "Cannot allocate %ld bytes of memory - Aborting\n", size);
 		fflush (stderr);
 		exit (1);
 	}

--- a/vbisam/tests/jvntest.c
+++ b/vbisam/tests/jvntest.c
@@ -110,17 +110,18 @@ main (int iargc, char **ppargv)
 		}
 		iloop1++;
 		cbuffer [170] = 0;
-	}
+	
                 for (iloop = 0; iloop < FILE_COUNT; iloop++)
-		{
+		
 			if (iswrite (ihandle [iloop], cbuffer))
 			{
 				printf ("Error %d writing row %d to file %d\n", iserrno, iloop1, iloop);
 				exit (1);
 			}
-			if (iloop1 > atoi (ppargv [1])) {
-				break;
-			}
+		if (iloop1 > atoi (ppargv [1])) 
+		{
+	             break;
+		}
 	}
 	fclose (pshandle);
 /*

--- a/vbisam/tests/jvntest.c
+++ b/vbisam/tests/jvntest.c
@@ -110,7 +110,9 @@ main (int iargc, char **ppargv)
 		}
 		iloop1++;
 		cbuffer [170] = 0;
-		for (iloop = 0; iloop < FILE_COUNT; iloop++)
+	}
+                for (iloop = 0; iloop < FILE_COUNT; iloop++)
+		{
 			if (iswrite (ihandle [iloop], cbuffer))
 			{
 				printf ("Error %d writing row %d to file %d\n", iserrno, iloop1, iloop);

--- a/vbisam/tests/mvtest.c
+++ b/vbisam/tests/mvtest.c
@@ -55,8 +55,8 @@ main (int iArgc, char **ppcArgv)
 		cRecord [256];
 	struct	keydesc
 		sKeydesc;
-	char	cLogfileName [95],
-		cCommand [204];
+	char	cLogfileName [100],
+		cCommand [213];
 	char	cFileName [] = "IsamTest";
 
 	memset (&sKeydesc, 0, sizeof (sKeydesc));

--- a/vbisam/tests/mvtest.c
+++ b/vbisam/tests/mvtest.c
@@ -93,6 +93,7 @@ main (int iArgc, char **ppcArgv)
 #else
 		sprintf (cCommand, "rm -f %s; touch %s", cLogfileName, cLogfileName);
 #endif
+		system (cCommand);
 		return (0);
 	}
 	sprintf (cLogfileName, "RECOVER");

--- a/vbisam/tests/mvtest.c
+++ b/vbisam/tests/mvtest.c
@@ -55,8 +55,8 @@ main (int iArgc, char **ppcArgv)
 		cRecord [256];
 	struct	keydesc
 		sKeydesc;
-	char	cLogfileName [100],
-		cCommand [100];
+	char	cLogfileName [95],
+		cCommand [204];
 	char	cFileName [] = "IsamTest";
 
 	memset (&sKeydesc, 0, sizeof (sKeydesc));
@@ -93,7 +93,6 @@ main (int iArgc, char **ppcArgv)
 #else
 		sprintf (cCommand, "rm -f %s; touch %s", cLogfileName, cLogfileName);
 #endif
-		system (cCommand);
 		return (0);
 	}
 	sprintf (cLogfileName, "RECOVER");


### PR DESCRIPTION
I have solved the warnings in ischeck.c, isdelete.c, isrecover.c, mvtest.c, vbmemio.c, vbisam.h. 
The warnings were wimplicit int in ischeck.c, wunused-set-variable in isdelete.c, wunused -result and buffer size in mvtest.c, wformat in vbmemio.c , expected long int in vbisam.h and wunused-set-variable and wincompatible pointer in isrecover.c