### PR TITLE
Warning/wformat truncation warnings resolved

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,7 +2,7 @@ name: NIST COBOL85 tests
 on:
   push:
   pull_request:
-    types: [opened, reopened, review_requested]
+    types: [opened, reopened, review_requested, synchronize]
     
 jobs:
   run-tests:

--- a/cobc/cobc.c
+++ b/cobc/cobc.c
@@ -240,6 +240,7 @@ static jmp_buf		cob_jmpbuf;
 
 static int		wants_nonfinal = 0;
 static int		cb_flag_module = 0;
+
 static int		cb_flag_library = 0;
 static int		save_temps = 0;
 static int		save_csrc = 0;

--- a/libcob/call.c
+++ b/libcob/call.c
@@ -28,6 +28,7 @@
 #include <ctype.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <strings.h>
 #ifdef	HAVE_UNISTD_H
 #include <unistd.h>
 #endif
@@ -586,7 +587,7 @@ cob_init_call (void)
 #ifndef	COB_ALT_HASH
 	call_table = cob_malloc (sizeof (struct call_hash *) * HASH_SIZE);
 #endif
-
+        int strcasecmp (const char *, const char *);
 	call_filename_buff = cob_malloc (CALL_FILEBUFF_SIZE);
 	call_entry_buff = cob_malloc (COB_SMALL_BUFF);
 	call_entry2_buff = cob_malloc (COB_SMALL_BUFF);

--- a/libcob/call.c
+++ b/libcob/call.c
@@ -28,7 +28,6 @@
 #include <ctype.h>
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <strings.h>
 #ifdef	HAVE_UNISTD_H
 #include <unistd.h>
 #endif
@@ -587,7 +586,6 @@ cob_init_call (void)
 #ifndef	COB_ALT_HASH
 	call_table = cob_malloc (sizeof (struct call_hash *) * HASH_SIZE);
 #endif
-        int strcasecmp (const char *, const char *);
 	call_filename_buff = cob_malloc (CALL_FILEBUFF_SIZE);
 	call_entry_buff = cob_malloc (COB_SMALL_BUFF);
 	call_entry2_buff = cob_malloc (COB_SMALL_BUFF);

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -1814,7 +1814,7 @@ cob_accept_time (cob_field *f)
 	time_t		t;
 #if defined(HAVE_SYS_TIME_H) && defined(HAVE_GETTIMEOFDAY)
 	struct timeval	tmv;
-	char		buff2[8];
+	char		buff2[18];
 #endif
 #endif
 	char		s[12];

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -27,6 +27,7 @@
 #include <string.h>
 #include <ctype.h>
 #include <time.h>
+#include <strings.h>
 
 #ifdef	HAVE_UNISTD_H
 #include <unistd.h>

--- a/libcob/common.c
+++ b/libcob/common.c
@@ -27,7 +27,6 @@
 #include <string.h>
 #include <ctype.h>
 #include <time.h>
-#include <strings.h>
 
 #ifdef	HAVE_UNISTD_H
 #include <unistd.h>
@@ -1814,7 +1813,7 @@ cob_accept_time (cob_field *f)
 	time_t		t;
 #if defined(HAVE_SYS_TIME_H) && defined(HAVE_GETTIMEOFDAY)
 	struct timeval	tmv;
-	char		buff2[18];
+	char		buff2[17];
 #endif
 #endif
 	char		s[12];

--- a/libcob/fileio.c
+++ b/libcob/fileio.c
@@ -211,7 +211,7 @@ DIR					*listdir_handle;
 struct dirent		*listdir_filedata;
 #endif
 
-#define        OPENMODESIZE  6
+#define        OPENMODESIZE  5
 #define        READOPTSSIZE  4
 #define        STARTCONDSIZE 2
 #define        EXCPTCODESIZE 6
@@ -4224,7 +4224,7 @@ cob_close (cob_file *f, const int opt, cob_field *fnstatus)
 {
 	char	openMode[OPENMODESIZE];
 
-	memset (openMode, 129, sizeof (openMode));
+	memset (openMode, 0, sizeof (openMode));
 	sprintf (openMode, "%02d", f->last_open_mode);
 	if (cob_invoke_fun (COB_IO_CLOSE, (char *)f, NULL, NULL, fnstatus, openMode, NULL, NULL)) {
 		return;

--- a/libcob/fileio.c
+++ b/libcob/fileio.c
@@ -211,7 +211,7 @@ DIR					*listdir_handle;
 struct dirent		*listdir_filedata;
 #endif
 
-#define        OPENMODESIZE  3
+#define        OPENMODESIZE  6
 #define        READOPTSSIZE  4
 #define        STARTCONDSIZE 2
 #define        EXCPTCODESIZE 6
@@ -4224,7 +4224,7 @@ cob_close (cob_file *f, const int opt, cob_field *fnstatus)
 {
 	char	openMode[OPENMODESIZE];
 
-	memset (openMode, 0, sizeof (openMode));
+	memset (openMode, 129, sizeof (openMode));
 	sprintf (openMode, "%02d", f->last_open_mode);
 	if (cob_invoke_fun (COB_IO_CLOSE, (char *)f, NULL, NULL, fnstatus, openMode, NULL, NULL)) {
 		return;

--- a/libcob/intrinsic.c
+++ b/libcob/intrinsic.c
@@ -1048,7 +1048,7 @@ cob_intr_current_date (const int offset, const int length)
 	cob_field	field;
 #if defined(HAVE_SYS_TIME_H) && defined(HAVE_GETTIMEOFDAY)
 	struct timeval	tmv;
-	char		buff2[8];
+	char		buff2[17];
 #endif
 #endif	/* _WIN32 */
 	char		buff[24];
@@ -1106,7 +1106,7 @@ cob_intr_current_date (const int offset, const int length)
 #endif
 
 #if defined(HAVE_SYS_TIME_H) && defined(HAVE_GETTIMEOFDAY)
-	snprintf(buff2, 7, "%2.2ld", tmv.tv_usec / 10000);
+	snprintf(buff2, 17, "%2.2ld", tmv.tv_usec / 10000);
 	memcpy (&buff[14], buff2, 2);
 #endif
 #endif	/* _WIN32 */
@@ -1246,7 +1246,7 @@ cob_intr_date_of_integer (cob_field *srcdays)
 	int		leapyear = 365;
 	cob_field_attr	attr;
 	cob_field	field;
-	char		buff[16];
+	char		buff[25];
 
 	COB_ATTR_INIT (COB_TYPE_NUMERIC_DISPLAY, 8, 0, 0, NULL);
 	COB_FIELD_INIT (8, NULL, &attr);
@@ -1282,7 +1282,7 @@ cob_intr_date_of_integer (cob_field *srcdays)
 			}
 		}
 	}
-	snprintf (buff, 15, "%4.4d%2.2d%2.2d", baseyear, i, days);
+	snprintf (buff, 25, "%4.4d%2.2d%2.2d", baseyear, i, days);
 	memcpy (curr_field->data, buff, 8);
 	return curr_field;
 }
@@ -1295,7 +1295,7 @@ cob_intr_day_of_integer (cob_field *srcdays)
 	int		leapyear = 365;
 	cob_field_attr	attr;
 	cob_field	field;
-	char		buff[16];
+	char		buff[19];
 
 	COB_ATTR_INIT (COB_TYPE_NUMERIC_DISPLAY, 7, 0, 0, NULL);
 	COB_FIELD_INIT (7, NULL, &attr);
@@ -1318,7 +1318,7 @@ cob_intr_day_of_integer (cob_field *srcdays)
 			leapyear = 365;
 		}
 	}
-	snprintf (buff, 15, "%4.4d%3.3d", baseyear, days);
+	snprintf (buff, 19, "%4.4d%3.3d", baseyear, days);
 	memcpy (curr_field->data, buff, 7);
 	return curr_field;
 }
@@ -1837,7 +1837,7 @@ cob_intr_numval (cob_field *srcfield)
 	cob_field	field;
 	unsigned char	integer_buff[64];
 	unsigned char	decimal_buff[64];
-	unsigned char	final_buff[64];
+	unsigned char	final_buff[130];
 
 	COB_ATTR_INIT (COB_TYPE_NUMERIC_BINARY, 18, 0, COB_FLAG_HAVE_SIGN, NULL);
 	COB_FIELD_INIT (8, NULL, &attr);
@@ -1894,7 +1894,7 @@ cob_intr_numval (cob_field *srcfield)
 		make_field_entry (&field);
 		memcpy (curr_field->data, (char *)&llval, 8);
 	} else {
-		snprintf ((char *)final_buff, 63, "%s%s.%s", sign ? "-" : "",
+		snprintf ((char *)final_buff, 130, "%s%s.%s", sign ? "-" : "",
 			 integer_buff, decimal_buff);
 		sscanf ((char *)final_buff, "%lf", &val);
 		make_double_entry ();
@@ -1918,7 +1918,7 @@ cob_intr_numval_c (cob_field *srcfield, cob_field *currency)
 	cob_field	field;
 	unsigned char	integer_buff[64];
 	unsigned char	decimal_buff[64];
-	unsigned char	final_buff[64];
+	unsigned char	final_buff[130];
 
 	COB_ATTR_INIT (COB_TYPE_NUMERIC_BINARY, 18, 0, COB_FLAG_HAVE_SIGN, NULL);
 	COB_FIELD_INIT (8, NULL, &attr);
@@ -1993,7 +1993,7 @@ cob_intr_numval_c (cob_field *srcfield, cob_field *currency)
 		make_field_entry (&field);
 		memcpy (curr_field->data, (char *)&llval, 8);
 	} else {
-		snprintf ((char *)final_buff, 63, "%s%s.%s", sign ? "-" : "",
+		snprintf ((char *)final_buff, 130, "%s%s.%s", sign ? "-" : "",
 			 integer_buff, decimal_buff);
 		sscanf ((char *)final_buff, "%lf", &val);
 		make_double_entry ();

--- a/libcob/intrinsic.c
+++ b/libcob/intrinsic.c
@@ -1246,7 +1246,7 @@ cob_intr_date_of_integer (cob_field *srcdays)
 	int		leapyear = 365;
 	cob_field_attr	attr;
 	cob_field	field;
-	char		buff[25];
+	char		buff[24];
 
 	COB_ATTR_INIT (COB_TYPE_NUMERIC_DISPLAY, 8, 0, 0, NULL);
 	COB_FIELD_INIT (8, NULL, &attr);
@@ -1282,7 +1282,7 @@ cob_intr_date_of_integer (cob_field *srcdays)
 			}
 		}
 	}
-	snprintf (buff, 25, "%4.4d%2.2d%2.2d", baseyear, i, days);
+	snprintf (buff, 24, "%4.4d%2.2d%2.2d", baseyear, i, days);
 	memcpy (curr_field->data, buff, 8);
 	return curr_field;
 }
@@ -1295,7 +1295,7 @@ cob_intr_day_of_integer (cob_field *srcdays)
 	int		leapyear = 365;
 	cob_field_attr	attr;
 	cob_field	field;
-	char		buff[19];
+	char		buff[18];
 
 	COB_ATTR_INIT (COB_TYPE_NUMERIC_DISPLAY, 7, 0, 0, NULL);
 	COB_FIELD_INIT (7, NULL, &attr);
@@ -1318,7 +1318,7 @@ cob_intr_day_of_integer (cob_field *srcdays)
 			leapyear = 365;
 		}
 	}
-	snprintf (buff, 19, "%4.4d%3.3d", baseyear, days);
+	snprintf (buff, 18, "%4.4d%3.3d", baseyear, days);
 	memcpy (curr_field->data, buff, 7);
 	return curr_field;
 }
@@ -1837,7 +1837,7 @@ cob_intr_numval (cob_field *srcfield)
 	cob_field	field;
 	unsigned char	integer_buff[64];
 	unsigned char	decimal_buff[64];
-	unsigned char	final_buff[130];
+	unsigned char	final_buff[129];
 
 	COB_ATTR_INIT (COB_TYPE_NUMERIC_BINARY, 18, 0, COB_FLAG_HAVE_SIGN, NULL);
 	COB_FIELD_INIT (8, NULL, &attr);
@@ -1894,7 +1894,7 @@ cob_intr_numval (cob_field *srcfield)
 		make_field_entry (&field);
 		memcpy (curr_field->data, (char *)&llval, 8);
 	} else {
-		snprintf ((char *)final_buff, 130, "%s%s.%s", sign ? "-" : "",
+		snprintf ((char *)final_buff, 129, "%s%s.%s", sign ? "-" : "",
 			 integer_buff, decimal_buff);
 		sscanf ((char *)final_buff, "%lf", &val);
 		make_double_entry ();
@@ -1918,7 +1918,7 @@ cob_intr_numval_c (cob_field *srcfield, cob_field *currency)
 	cob_field	field;
 	unsigned char	integer_buff[64];
 	unsigned char	decimal_buff[64];
-	unsigned char	final_buff[130];
+	unsigned char	final_buff[129];
 
 	COB_ATTR_INIT (COB_TYPE_NUMERIC_BINARY, 18, 0, COB_FLAG_HAVE_SIGN, NULL);
 	COB_FIELD_INIT (8, NULL, &attr);
@@ -1993,7 +1993,7 @@ cob_intr_numval_c (cob_field *srcfield, cob_field *currency)
 		make_field_entry (&field);
 		memcpy (curr_field->data, (char *)&llval, 8);
 	} else {
-		snprintf ((char *)final_buff, 130, "%s%s.%s", sign ? "-" : "",
+		snprintf ((char *)final_buff, 129, "%s%s.%s", sign ? "-" : "",
 			 integer_buff, decimal_buff);
 		sscanf ((char *)final_buff, "%lf", &val);
 		make_double_entry ();

--- a/libcob/screenio.c
+++ b/libcob/screenio.c
@@ -489,7 +489,7 @@ cob_check_pos_status (int fret)
 	cob_field	*f;
 	int		sline;
 	int		scolumn;
-	char		datbuf[8];
+	char		datbuf[10];
 
 	if (fret) {
 		cob_set_exception (COB_EC_IMP_ACCEPT);

--- a/vbisam/libvbisam/vblowlevel.c
+++ b/vbisam/libvbisam/vblowlevel.c
@@ -39,7 +39,7 @@ ivbopen (const char *pcfilename, const int iflags, const mode_t tmode)
 		iinitialized = 1;
 	}
 	if (stat (pcfilename, &sstat)) {
-		if (!iflags & O_CREAT) {
+		if (~iflags & O_CREAT) {
 			return -1;
 		}
 	} else {

--- a/vbisam/libvbisam/vblowlevel.c
+++ b/vbisam/libvbisam/vblowlevel.c
@@ -39,7 +39,7 @@ ivbopen (const char *pcfilename, const int iflags, const mode_t tmode)
 		iinitialized = 1;
 	}
 	if (stat (pcfilename, &sstat)) {
-		if (~iflags & O_CREAT) {
+		if (!iflags & O_CREAT) {
 			return -1;
 		}
 	} else {


### PR DESCRIPTION
wformat_truncation warnings in the line 1109, 1285,67,1321 are1897 resolved in intrinsic.c file.
Solution: (n + 1 byte) where n = buff size
Increase the buff size at 1051 line for 1109, 1249 line for 1285, 1298 line for 1321, 1840 line for 1897 and 1921 line for 1997. Even change the buff size at the line 1109, 1285, 1321, 1897 and 1997 .